### PR TITLE
Adding Bitcode Generation Mode

### DIFF
--- a/Signals.xcodeproj/project.pbxproj
+++ b/Signals.xcodeproj/project.pbxproj
@@ -351,7 +351,6 @@
 		720D11891A085315003C4361 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BITCODE_GENERATION_MODE = marker;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -373,7 +372,6 @@
 		720D118A1A085315003C4361 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BITCODE_GENERATION_MODE = bitcode;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Signals.xcodeproj/project.pbxproj
+++ b/Signals.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 		720D11891A085315003C4361 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = marker;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -372,6 +373,7 @@
 		720D118A1A085315003C4361 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Signals.xcodeproj/project.pbxproj
+++ b/Signals.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Signals/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-Xlinker",
@@ -380,7 +380,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Signals/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-Xlinker",


### PR DESCRIPTION
Archiving our binary is currently no longer possible if we include your current framework. 

     ld: bitcode bundle could not be generated because
     '/Users/hibento/Repositories/app/Carthage/Build/iOS/Signals.framework/Signals' 
     was built without full bitcode. All frameworks and dylibs for bitcode must be generated from Xcode Archive or Install build for architecture arm64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)

Adding the User defined Compiler Setting "BITCODE_GENERATION_MODE" we could solve this issue. See also [Carthage Issue 45](https://github.com/jspahrsummers/xcconfigs/issues/45)