### PR TITLE
Set the dispatch queue explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ networkLoader.onProgress.listen(self) { (progress) in
 }.queueAndDelayBy(1.0)
 ```
 
+A signal dispatches listener calls synchronously on the posting thread by default. To specify the thread explicitly, you should use the `dispatchOnQueue` method:
+
+```swift
+networkLoader.onProgress.listen(self) { (progress) in
+    // This fires on the main queue
+}.dispatchOnQueue(dispatch_get_main_queue())
+```
+
 If you don't like the double quotes that you have to use since Swift 2.0 when you fire singlas that take tuples, you can use a special operator to fire the data:
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ networkLoader.onProgress.listen(self) { (progress) in
 }.queueAndDelayBy(1.0)
 ```
 
-A signal dispatches listener calls synchronously on the posting thread by default. To specify the thread explicitly, you should use the `dispatchOnQueue` method:
+A signal dispatches listener calls synchronously on the posting thread by default. To define the thread explicitly, you should use the `dispatchOnQueue` method. In this way you will receive listener calls asynchronously on the specified queue:
 
 ```swift
 networkLoader.onProgress.listen(self) { (progress) in
@@ -121,7 +121,7 @@ networkLoader.onProgress.listen(self) { (progress) in
 }.dispatchOnQueue(dispatch_get_main_queue())
 ```
 
-If you don't like the double quotes that you have to use since Swift 2.0 when you fire singlas that take tuples, you can use a special operator to fire the data:
+If you don't like the double quotes that you have to use since Swift 2.0 when you fire signals that take tuples, you can use a special operator to fire the data:
 
 ```swift
 // If you don't like the double quotes when firing signals that have tuples

--- a/Signals/Signal.swift
+++ b/Signals/Signal.swift
@@ -218,8 +218,9 @@ public class SignalListener<T> {
         return self
     }
 
-    /// Assigns a dispatch queue to the SignalListener. The queue is used to dispatch the signal fire to the listener. 
-    /// If you pass nil, the block is run synchronously on the posting thread.
+    /// Assigns a dispatch queue to the SignalListener. The queue is used for scheduling the listener calls. If not nil,
+    /// the callback is fired asynchronously on the specified queue. Otherwise, the block is run synchronously on the
+    /// posting thread (default behaviour).
     ///
     /// - parameter queue: A queue for performing the listener's calls.
     /// - returns: Returns self so you can chain calls.

--- a/SignalsTests/SingalQueueTests.swift
+++ b/SignalsTests/SingalQueueTests.swift
@@ -140,7 +140,6 @@ class SignalQueueTests: XCTestCase {
         let secondQueueLabel = "com.signals.queue.second";
         let secondQueue = dispatch_queue_create(secondQueueLabel, DISPATCH_QUEUE_CONCURRENT)
 
-        var dispatchCount = 0
         let firstListener = NSObject()
         let secondListener = NSObject()
 
@@ -148,21 +147,18 @@ class SignalQueueTests: XCTestCase {
         emitter.onInt.listen(firstListener, callback: { (argument) in
             let currentQueueLabel = String(UTF8String: dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL))
             XCTAssertTrue(firstQueueLabel == currentQueueLabel)
-            dispatchCount++
             firstExpectation.fulfill()
         }).dispatchOnQueue(firstQueue)
         let secondExpectation = expectationWithDescription("secondDispatchOnQueue")
         emitter.onInt.listen(secondListener, callback: { (argument) in
             let currentQueueLabel = String(UTF8String: dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL))
             XCTAssertTrue(secondQueueLabel == currentQueueLabel)
-            dispatchCount++
             secondExpectation.fulfill()
         }).dispatchOnQueue(secondQueue)
 
         emitter.onInt.fire(10)
 
         waitForExpectationsWithTimeout(0.05, handler: nil)
-        XCTAssertEqual(dispatchCount, 2, "Should be dispatched twice!")
     }
 
     func testUsesCurrentQueueByDefault() {

--- a/SignalsTests/SingalQueueTests.swift
+++ b/SignalsTests/SingalQueueTests.swift
@@ -158,7 +158,7 @@ class SignalQueueTests: XCTestCase {
 
         emitter.onInt.fire(10)
 
-        waitForExpectationsWithTimeout(0.05, handler: nil)
+        waitForExpectationsWithTimeout(0.2, handler: nil)
     }
 
     func testUsesCurrentQueueByDefault() {
@@ -178,7 +178,7 @@ class SignalQueueTests: XCTestCase {
             self.emitter.onInt.fire(10)
         }
 
-        waitForExpectationsWithTimeout(0.05, handler: nil)
+        waitForExpectationsWithTimeout(0.2, handler: nil)
     }
 
 }


### PR DESCRIPTION
A signal dispatches listener calls synchronously on the posting thread by default.
Added the `dispatchOnQueue` method to specify the queue explicitly. Updated the readme file and implemented unit tests.