### PR TITLE
Resolved Swift-3.0 warnings

### DIFF
--- a/Signals/Signal.swift
+++ b/Signals/Signal.swift
@@ -378,7 +378,11 @@ public class SignalListener<T> {
     }
 }
 
-infix operator => { associativity left precedence 0 }
+precedencegroup ExponentiativePrecedence {
+    associativity: left
+}
+
+infix operator =>: ExponentiativePrecedence
 
 public func =><T> (signal: Signal<T>, data: T) -> Void {
     signal.fire(data)

--- a/Signals/ios/AssociatedObject.swift
+++ b/Signals/ios/AssociatedObject.swift
@@ -9,13 +9,12 @@
 import ObjectiveC
 
 #if swift(>=3.0)
-    func setAssociatedObject<T>(_ object: AnyObject, value: T, associativeKey: UnsafePointer<Void>, policy: objc_AssociationPolicy) {
-        if let valueAsAnyObject = value as? AnyObject {
-            objc_setAssociatedObject(object, associativeKey, valueAsAnyObject, policy)
-        }
+    func setAssociatedObject<T>(_ object: AnyObject, value: T, associativeKey: UnsafeRawPointer, policy: objc_AssociationPolicy) {
+        let valueAsAnyObject = value as AnyObject
+        objc_setAssociatedObject(object, associativeKey, valueAsAnyObject, policy)
     }
 
-    func getAssociatedObject<T>(_ object: AnyObject, associativeKey: UnsafePointer<Void>) -> T? {
+    func getAssociatedObject<T>(_ object: AnyObject, associativeKey: UnsafeRawPointer) -> T? {
         if let valueAsType = objc_getAssociatedObject(object, associativeKey) as? T {
             return valueAsType
         } else {
@@ -23,7 +22,7 @@ import ObjectiveC
         }
     }
 
-    func getOrCreateAssociatedObject<T>(_ object: AnyObject, associativeKey: UnsafePointer<Void>, defaultValue:T, policy: objc_AssociationPolicy) -> T {
+    func getOrCreateAssociatedObject<T>(_ object: AnyObject, associativeKey: UnsafeRawPointer, defaultValue:T, policy: objc_AssociationPolicy) -> T {
         if let valueAsType: T = getAssociatedObject(object, associativeKey: associativeKey) {
             return valueAsType
         }


### PR DESCRIPTION
- UnsafePointer<Void> has been replaced by UnsafeRawPointer
- operator should no longer be declared with body; use a precedence group instead
- non-optional expression of type 'AnyObject' used in a check for optionals