### PR TITLE
Specify full version in SPM instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To integrate Signals into your project using SwiftPM add the following to your `
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/artman/Signals", from: "6.0"),
+    .package(url: "https://github.com/artman/Signals", from: "6.0.0"),
 ],
 ```
 


### PR DESCRIPTION
Recent Swift versions require the version specifier in `"from"` to be a full version, otherwise it'll give the following error:

```text
error: manifest parse error(s):
Invalid version string: 6.0
```