### PR TITLE
Added helper function to simplify .fire() when using a Void type

### DIFF
--- a/Signals/Signal.swift
+++ b/Signals/Signal.swift
@@ -60,7 +60,7 @@ final public class Signal<T> {
     @discardableResult
     public func subscribe(with observer: AnyObject, callback: @escaping SignalCallback) -> SignalSubscription<T> {
         flushCancelledListeners()
-        let signalListener = SignalSubscription<T>(observer: observer, callback: callback);
+        let signalListener = SignalSubscription<T>(observer: observer, callback: callback)
         signalListeners.append(signalListener)
         return signalListener
     }
@@ -170,6 +170,12 @@ final public class Signal<T> {
                 return $0.observer != nil
             }
         }
+    }
+}
+
+public extension Signal where T == Void {
+    public func fire() {
+        fire(())
     }
 }
 

--- a/Signals/ios/AssociatedObject.swift
+++ b/Signals/ios/AssociatedObject.swift
@@ -21,5 +21,5 @@ func getOrCreateAssociatedObject<T>(_ object: AnyObject, associativeKey: UnsafeR
         return valueAsType
     }
     setAssociatedObject(object, value: defaultValue, associativeKey: associativeKey, policy: policy)
-    return defaultValue;
+    return defaultValue
 }

--- a/Signals/ios/UIBarButtonItem+Signals.swift
+++ b/Signals/ios/UIBarButtonItem+Signals.swift
@@ -14,7 +14,7 @@ import UIKit
 public extension UIBarButtonItem {
     /// A signal that fires for each action event.
     public var onAction: Signal<(Void)> {
-        return getOrCreateSignal();
+        return getOrCreateSignal()
     }
 
     // MARK: - Private interface
@@ -27,10 +27,10 @@ public extension UIBarButtonItem {
         let key = "Action"
         let dictionary = getOrCreateAssociatedObject(self, associativeKey: &AssociatedKeys.SignalDictionaryKey, defaultValue: NSMutableDictionary(), policy: objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
-        if let signal = dictionary[key] as? Signal<()> {
+        if let signal = dictionary[key] as? Signal<Void> {
             return signal
         } else {
-            let signal = Signal<()>()
+            let signal = Signal<Void>()
             dictionary[key] = signal
             self.target = self
             self.action = #selector(eventHandlerAction)
@@ -39,7 +39,7 @@ public extension UIBarButtonItem {
     }
 
     @objc private dynamic func eventHandlerAction() {
-        getOrCreateSignal().fire(())
+        getOrCreateSignal().fire()
     }
 }
 

--- a/Signals/ios/UIControl+Signals.swift
+++ b/Signals/ios/UIControl+Signals.swift
@@ -10,72 +10,72 @@ import UIKit
 public extension UIControl {
     /// A signal that fires for each touch down control event.
     public var onTouchDown: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchDown);
+        return getOrCreateSignalForUIControlEvent(.touchDown)
     }
 
     /// A signal that fires for each touch down repeat control event.
     public var onTouchDownRepeat: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchDownRepeat);
+        return getOrCreateSignalForUIControlEvent(.touchDownRepeat)
     }
 
     /// A signal that fires for each touch drag inside control event.
     public var onTouchDragInside: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchDragInside);
+        return getOrCreateSignalForUIControlEvent(.touchDragInside)
     }
 
     /// A signal that fires for each touch drag outside control event.
     public var onTouchDragOutside: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchDragOutside);
+        return getOrCreateSignalForUIControlEvent(.touchDragOutside)
     }
 
     /// A signal that fires for each touch drag enter control event.
     public var onTouchDragEnter: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchDragEnter);
+        return getOrCreateSignalForUIControlEvent(.touchDragEnter)
     }
 
     /// A signal that fires for each touch drag exit control event.
     public var onTouchDragExit: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchDragExit);
+        return getOrCreateSignalForUIControlEvent(.touchDragExit)
     }
 
     /// A signal that fires for each touch up inside control event.
     public var onTouchUpInside: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchUpInside);
+        return getOrCreateSignalForUIControlEvent(.touchUpInside)
     }
 
     /// A signal that fires for each touch up outside control event.
     public var onTouchUpOutside: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchUpOutside);
+        return getOrCreateSignalForUIControlEvent(.touchUpOutside)
     }
 
     /// A signal that fires for each touch cancel control event.
     public var onTouchCancel: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.touchCancel);
+        return getOrCreateSignalForUIControlEvent(.touchCancel)
     }
 
     /// A signal that fires for each value changed control event.
     public var onValueChanged: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.valueChanged);
+        return getOrCreateSignalForUIControlEvent(.valueChanged)
     }
 
     /// A signal that fires for each editing did begin control event.
     public var onEditingDidBegin: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.editingDidBegin);
+        return getOrCreateSignalForUIControlEvent(.editingDidBegin)
     }
 
     /// A signal that fires for each editing changed control event.
     public var onEditingChanged: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.editingChanged);
+        return getOrCreateSignalForUIControlEvent(.editingChanged)
     }
 
     /// A signal that fires for each editing did end control event.
     public var onEditingDidEnd: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.editingDidEnd);
+        return getOrCreateSignalForUIControlEvent(.editingDidEnd)
     }
 
     /// A signal that fires for each editing did end on exit control event.
     public var onEditingDidEndOnExit: Signal<(Void)> {
-        return getOrCreateSignalForUIControlEvent(.editingDidEndOnExit);
+        return getOrCreateSignalForUIControlEvent(.editingDidEndOnExit)
     }
 
     // MARK: - Private interface
@@ -107,10 +107,10 @@ public extension UIControl {
         }
         let dictionary = getOrCreateAssociatedObject(self, associativeKey: &AssociatedKeys.SignalDictionaryKey, defaultValue: NSMutableDictionary(), policy: objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
-        if let signal = dictionary[key] as? Signal<()> {
+        if let signal = dictionary[key] as? Signal<Void> {
             return signal
         } else {
-            let signal = Signal<()>()
+            let signal = Signal<Void>()
             dictionary[key] = signal
             self.addTarget(self, action: Selector("eventHandler\(key)"), for: event)
             return signal
@@ -118,7 +118,7 @@ public extension UIControl {
     }
 
     private func handleUIControlEvent(_ uiControlEvent: UIControl.Event) {
-        getOrCreateSignalForUIControlEvent(uiControlEvent).fire(())
+        getOrCreateSignalForUIControlEvent(uiControlEvent).fire()
     }
 
     @objc private dynamic func eventHandlerTouchDown() {

--- a/SignalsTests/SignalEmitter.swift
+++ b/SignalsTests/SignalEmitter.swift
@@ -6,7 +6,7 @@ import Foundation
 import Signals
 
 class SignalEmitter {
-    let onNoParams = Signal<()>(retainLastData: true)
+    let onNoParams = Signal<Void>(retainLastData: true)
     let onInt = Signal<Int>(retainLastData: true)
     let onString = Signal<String>(retainLastData: true)
     let onIntAndString = Signal<(intArgument: Int, stringArgument: String)>(retainLastData: true)

--- a/SignalsTests/SignalsTests.swift
+++ b/SignalsTests/SignalsTests.swift
@@ -11,7 +11,7 @@ import Dispatch
 
 class SignalsTests: XCTestCase {
     
-    var emitter:SignalEmitter = SignalEmitter();
+    var emitter:SignalEmitter = SignalEmitter()
     
     override func setUp() {
         super.setUp()
@@ -30,14 +30,14 @@ class SignalsTests: XCTestCase {
         var stringSignalResult = ""
         
         emitter.onInt.subscribe(with: self, callback: { (argument) in
-            intSignalResult = argument;
+            intSignalResult = argument
         })
         emitter.onString.subscribe(with: self, callback: { (argument) in
-            stringSignalResult = argument;
+            stringSignalResult = argument
         })
         
-        emitter.onInt.fire(1);
-        emitter.onString.fire("test");
+        emitter.onInt.fire(1)
+        emitter.onString.fire("test")
         
         XCTAssertEqual(intSignalResult, 1, "IntSignal catched")
         XCTAssertEqual(stringSignalResult, "test", "StringSignal catched")
@@ -47,10 +47,10 @@ class SignalsTests: XCTestCase {
         var signalCount = 0
         
         emitter.onNoParams.subscribe(with: self, callback: { () -> Void in
-            signalCount += 1;
+            signalCount += 1
         })
         
-        emitter.onNoParams.fire(());
+        emitter.onNoParams.fire()
         
         XCTAssertEqual(signalCount, 1, "Signal catched")
     }
@@ -284,7 +284,7 @@ class SignalsTests: XCTestCase {
     func test_postSubscriptionNoData() {
         var dispatchCount = 0
         
-        emitter.onNoParams.fire(())
+        emitter.onNoParams.fire()
         
         emitter.onNoParams.subscribePast(with: self, callback: { () -> Void in
             dispatchCount += 1

--- a/SignalsTests/SingalQueueTests.swift
+++ b/SignalsTests/SingalQueueTests.swift
@@ -11,7 +11,7 @@ import Dispatch
 
 class SignalQueueTests: XCTestCase {
     
-    var emitter:SignalEmitter = SignalEmitter();
+    var emitter:SignalEmitter = SignalEmitter()
     
     override func setUp() {
         super.setUp()
@@ -30,7 +30,7 @@ class SignalQueueTests: XCTestCase {
             expectation.fulfill()
         }).sample(every: 0.1)
 
-        emitter.onInt.fire(1);
+        emitter.onInt.fire(1)
 
         waitForExpectations(timeout: 10.0, handler: nil)
     }
@@ -43,9 +43,9 @@ class SignalQueueTests: XCTestCase {
             expectation.fulfill()
         }).sample(every: 0.1)
         
-        emitter.onInt.fire(1);
-        emitter.onInt.fire(2);
-        emitter.onInt.fire(3);
+        emitter.onInt.fire(1)
+        emitter.onInt.fire(2)
+        emitter.onInt.fire(3)
         
         waitForExpectations(timeout: 10.0, handler: nil)
     }
@@ -58,9 +58,9 @@ class SignalQueueTests: XCTestCase {
             expectation.fulfill()
         }).sample(every: 0.0)
         
-        emitter.onInt.fire(1);
-        emitter.onInt.fire(2);
-        emitter.onInt.fire(3);
+        emitter.onInt.fire(1)
+        emitter.onInt.fire(2)
+        emitter.onInt.fire(3)
         
         waitForExpectations(timeout: 10.0, handler: nil)
     }
@@ -114,9 +114,9 @@ class SignalQueueTests: XCTestCase {
             expectation.fulfill()
         }).sample(every: 0.01)
         
-        emitter.onNoParams.fire(())
-        emitter.onNoParams.fire(())
-        emitter.onNoParams.fire(())
+        emitter.onNoParams.fire()
+        emitter.onNoParams.fire()
+        emitter.onNoParams.fire()
         
         waitForExpectations(timeout: 10.0, handler: nil)
     }
@@ -138,8 +138,8 @@ class SignalQueueTests: XCTestCase {
     }
 
     func testListeningOnDispatchQueue() {
-        let firstQueueLabel = "com.signals.queue.first";
-        let secondQueueLabel = "com.signals.queue.second";
+        let firstQueueLabel = "com.signals.queue.first"
+        let secondQueueLabel = "com.signals.queue.second"
 
         let labelKey = DispatchSpecificKey<String>()
         let firstQueue = DispatchQueue(label: firstQueueLabel)
@@ -169,7 +169,7 @@ class SignalQueueTests: XCTestCase {
     }
 
     func testUsesCurrentQueueByDefault() {
-        let queueLabel = "com.signals.queue";
+        let queueLabel = "com.signals.queue"
 
         let labelKey = DispatchSpecificKey<String>()
         let queue = DispatchQueue(label: queueLabel, attributes: DispatchQueue.Attributes.concurrent)

--- a/SignalsTests/TestListener.swift
+++ b/SignalsTests/TestListener.swift
@@ -6,14 +6,14 @@ import Foundation
 import Signals
 
 class TestListener {
-    var dispatchCount: Int = 0;
-    var lastArgument: Int = 0;
+    var dispatchCount: Int = 0
+    var lastArgument: Int = 0
     
     func subscribe(to emitter: SignalEmitter) {
         emitter.onInt.subscribe(with: self, callback: {
             [unowned self] (argument) in
             self.dispatchCount += 1
-            self.lastArgument = argument;
+            self.lastArgument = argument
         })
     }
     
@@ -21,7 +21,7 @@ class TestListener {
         emitter.onInt.subscribeOnce(with: self, callback: {
             [unowned self] (argument) in
             self.dispatchCount += 1
-            self.lastArgument = argument;
+            self.lastArgument = argument
         })
     }
 
@@ -37,7 +37,7 @@ class TestListener {
         emitter.onInt.subscribePast(with: self, callback: {
             [unowned self] (argument) in
             self.dispatchCount += 1
-            self.lastArgument = argument;
+            self.lastArgument = argument
         })
     }
 }

--- a/SignalsTests/UIControl+SignalsTests.swift
+++ b/SignalsTests/UIControl+SignalsTests.swift
@@ -72,10 +72,10 @@ class UIControl_SignalsTests: XCTestCase {
         let events: [UIControl.Event] = [.touchDown, .touchDownRepeat, .touchDragInside, .touchDragOutside,
                                          .touchDragEnter, .touchDragExit, .touchUpInside, .touchUpOutside,
                                          .touchCancel, .valueChanged, .editingDidBegin, .editingChanged,
-                                         .editingDidEnd, .editingDidEndOnExit];
+                                         .editingDidEnd, .editingDidEndOnExit]
 
         for event in events {
-            let actions = button.actions(forTarget: button, forControlEvent: event);
+            let actions = button.actions(forTarget: button, forControlEvent: event)
             for action in actions! {
                 button.perform(Selector(action))
             }


### PR DESCRIPTION
This makes it so that you can call `.fire()` without having to pass an empty tuple.

* Also cleaned up some code-smell semicolons