### PR TITLE
Add "Property" struct

### DIFF
--- a/Signals/Signal.swift
+++ b/Signals/Signal.swift
@@ -340,7 +340,7 @@ public struct Property<T> {
     }
 
     /// Subscribes an observer to the Property and invokes its callback immediately with the current value
-    public func observe(whileAlive observer: AnyObject, callback: @escaping (T) -> Void) {
+    public func observe(with observer: AnyObject, callback: @escaping (T) -> Void) {
         signal.subscribePast(with: observer, callback: callback)
     }
 }

--- a/SignalsTests/SignalsTests.swift
+++ b/SignalsTests/SignalsTests.swift
@@ -415,7 +415,7 @@ class PropertyTests: XCTestCase {
         XCTAssertEqual(sut.value, 10)
         let subscription = NSObject()
         let expectation = XCTestExpectation(description: "Subscriber should be notified about the update")
-        sut.observe(whileAlive: subscription) { value in
+        sut.observe(with: subscription) { value in
             XCTAssertEqual(value, 10)
             expectation.fulfill()
         }
@@ -428,7 +428,7 @@ class PropertyTests: XCTestCase {
         let subscription = NSObject()
         let expectation = XCTestExpectation(description: "Subscriber should be notified about the update")
         var dispatchCount = 0
-        sut.observe(whileAlive: subscription) { value in
+        sut.observe(with: subscription) { value in
             dispatchCount += 1
             if dispatchCount > 1 {
                 XCTAssertEqual(value, 5)
@@ -443,7 +443,7 @@ class PropertyTests: XCTestCase {
         var sut = Property(value: "abc")
         var subscription: NSObject? = NSObject()
         var dispatchCount = 0
-        sut.observe(whileAlive: subscription!) { value in
+        sut.observe(with: subscription!) { value in
             dispatchCount += 1
             if dispatchCount > 1 {
                 XCTFail("Subscription should be cancelled")
@@ -462,7 +462,7 @@ class PropertyTests: XCTestCase {
         var sut = Property(value: false)
         let subscription = NSObject()
         var dispatchCount = 0
-        sut.observe(whileAlive: subscription) { value in
+        sut.observe(with: subscription) { value in
             dispatchCount += 1
             if dispatchCount > 1 {
                 XCTFail("Subscription should be cancelled")
@@ -470,7 +470,7 @@ class PropertyTests: XCTestCase {
         }
         sut.signal.cancelSubscription(for: subscription)
         sut.value = true
-        sut.observe(whileAlive: subscription) { value in
+        sut.observe(with: subscription) { value in
             dispatchCount += 1
             if dispatchCount > 2 {
                 XCTFail("Subscription should be cancelled")

--- a/SignalsTests/SignalsTests.swift
+++ b/SignalsTests/SignalsTests.swift
@@ -407,3 +407,76 @@ class SignalsTests: XCTestCase {
         }
     }
 }
+
+class PropertyTests: XCTestCase {
+
+    func test_observe_shouldFireCallbackWithCurrentValue() {
+        let sut = Property(value: 10)
+        XCTAssertEqual(sut.value, 10)
+        let subscription = NSObject()
+        let expectation = XCTestExpectation(description: "Subscriber should be notified about the update")
+        sut.observe(whileAlive: subscription) { value in
+            XCTAssertEqual(value, 10)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func test_valueSetter_shouldChangeTheValueAndFireSubscriptionCallback() {
+        var sut = Property(value: 10)
+        XCTAssertEqual(sut.value, 10)
+        let subscription = NSObject()
+        let expectation = XCTestExpectation(description: "Subscriber should be notified about the update")
+        var dispatchCount = 0
+        sut.observe(whileAlive: subscription) { value in
+            dispatchCount += 1
+            if dispatchCount > 1 {
+                XCTAssertEqual(value, 5)
+                expectation.fulfill()
+            }
+        }
+        sut.value = 5
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func test_automaticCancellation() {
+        var sut = Property(value: "abc")
+        var subscription: NSObject? = NSObject()
+        var dispatchCount = 0
+        sut.observe(whileAlive: subscription!) { value in
+            dispatchCount += 1
+            if dispatchCount > 1 {
+                XCTFail("Subscription should be cancelled")
+            }
+        }
+        subscription = nil
+        let expectation = XCTestExpectation(description: "Delay")
+        DispatchQueue.main.async {
+            sut.value = "def"
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func test_manualCancellation() {
+        var sut = Property(value: false)
+        let subscription = NSObject()
+        var dispatchCount = 0
+        sut.observe(whileAlive: subscription) { value in
+            dispatchCount += 1
+            if dispatchCount > 1 {
+                XCTFail("Subscription should be cancelled")
+            }
+        }
+        sut.signal.cancelSubscription(for: subscription)
+        sut.value = true
+        sut.observe(whileAlive: subscription) { value in
+            dispatchCount += 1
+            if dispatchCount > 2 {
+                XCTFail("Subscription should be cancelled")
+            }
+        }
+        sut.signal.cancelAllSubscriptions()
+        sut.value = false
+    }
+}


### PR DESCRIPTION
This adds an observable property inspired by [Property](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Property.swift) from ReactiveSwift, and [BehaviorSubject](https://github.com/ReactiveX/RxSwift/blob/6b2a406b928cc7970874dcaed0ab18e7265e41ef/RxSwift/Subjects/BehaviorSubject.swift) from RxSwift.

This implementation of the observable property has an advantage over analogs from RxSwift and ReactiveSwift because it supports defining different Access Levels to setter and getter, which is [impossible to achieve](https://github.com/ReactiveCocoa/ReactiveSwift/issues/19) in those libraries.

Aiming to maintain the philosophy of simplicity of the Signal, this implementation of the Property doesn't replicate all the functional features inherent to the FRP libraries, such as mapping the value or combining with other properties. Instead, it focuses on the observation feature only.

> Signals is a library for creating and observing events. It replaces delegates, actions and NSNotificationCenter with something much more powerful and elegant.

With this addition, the Signals would also offer a replacement for the Key-Value-Observation.

``` swift
class MyClass {
    private(set) var property = Property(value: "abc")

    func mutateProperty() {
        property.value = "xyz"
    }
}

let object = MyClass()
print("\(object.property.value)") // getter returns "abc"

// Attempt to change the value from outside the class:
object.property.value = "qwe" // Compiler error - setter is private

// Subscribing for new values
object.property.observe(with: self) { value in
    print("\(value)")
}

object.mutateProperty() // triggers the notification with the new value "xyz"
```