### PR TITLE
Expose signal for .primaryActionTriggered (on tvOS)

### DIFF
--- a/Signals/ios/UIControl+Signals.swift
+++ b/Signals/ios/UIControl+Signals.swift
@@ -77,6 +77,13 @@ public extension UIControl {
     var onEditingDidEndOnExit: Signal<Void> {
         return getOrCreateSignalForUIControlEvent(.editingDidEndOnExit)
     }
+    
+    #if os(tvOS)
+    /// A signal that fires for the primary action triggered (used in tvOS) control event.
+    var onPrimaryActionTriggered: Signal<Void> {
+        return getOrCreateSignalForUIControlEvent(.primaryActionTriggered)
+    }
+    #endif
 
     // MARK: - Private interface
 
@@ -84,21 +91,28 @@ public extension UIControl {
         static var SignalDictionaryKey = "signals_signalKey"
     }
 
-    private static let eventToKey: [UIControl.Event: NSString] = [
-        .touchDown: "TouchDown",
-        .touchDownRepeat: "TouchDownRepeat",
-        .touchDragInside: "TouchDragInside",
-        .touchDragOutside: "TouchDragOutside",
-        .touchDragEnter: "TouchDragEnter",
-        .touchDragExit: "TouchDragExit",
-        .touchUpInside: "TouchUpInside",
-        .touchUpOutside: "TouchUpOutside",
-        .touchCancel: "TouchCancel",
-        .valueChanged: "ValueChanged",
-        .editingDidBegin: "EditingDidBegin",
-        .editingChanged: "EditingChanged",
-        .editingDidEnd: "EditingDidEnd",
-        .editingDidEndOnExit: "EditingDidEndOnExit"]
+    private static let eventToKey: [UIControl.Event: NSString] = {
+        var mapping: [UIControl.Event: NSString] = [
+            .touchDown: "TouchDown",
+            .touchDownRepeat: "TouchDownRepeat",
+            .touchDragInside: "TouchDragInside",
+            .touchDragOutside: "TouchDragOutside",
+            .touchDragEnter: "TouchDragEnter",
+            .touchDragExit: "TouchDragExit",
+            .touchUpInside: "TouchUpInside",
+            .touchUpOutside: "TouchUpOutside",
+            .touchCancel: "TouchCancel",
+            .valueChanged: "ValueChanged",
+            .editingDidBegin: "EditingDidBegin",
+            .editingChanged: "EditingChanged",
+            .editingDidEnd: "EditingDidEnd",
+            .editingDidEndOnExit: "EditingDidEndOnExit"
+        ]
+        #if os(tvOS)
+        mapping[.primaryActionTriggered] = "PrimaryActionTriggered"
+        #endif
+        return mapping
+    }()
 
     private func getOrCreateSignalForUIControlEvent(_ event: UIControl.Event) -> Signal<Void> {
         guard let key = UIControl.eventToKey[event] else {
@@ -176,6 +190,12 @@ public extension UIControl {
     @objc private dynamic func eventHandlerEditingDidEndOnExit() {
         handleUIControlEvent(.editingDidEndOnExit)
     }
+    
+    #if os(tvOS)
+    @objc private dynamic func eventHandlerPrimaryActionTriggered() {
+        handleUIControlEvent(.primaryActionTriggered)
+    }
+    #endif
 }
 
 extension UIControl.Event: Hashable {

--- a/SignalsTests/UIControl+SignalsTests.swift
+++ b/SignalsTests/UIControl+SignalsTests.swift
@@ -25,6 +25,9 @@ class UIControl_SignalsTests: XCTestCase {
         var onEditingChangedCount = 0
         var onEditingDidEndCount = 0
         var onEditingDidEndOnExitCount = 0
+        #if os(tvOS)
+        var onPrimaryActionTriggeredCount = 0
+        #endif
 
         button.onTouchDown.subscribe(with: self) { _ in
             onTouchDownCount += 1
@@ -68,7 +71,13 @@ class UIControl_SignalsTests: XCTestCase {
         button.onEditingDidEndOnExit.subscribe(with: self) { _ in
             onEditingDidEndOnExitCount += 1
         }
-
+        
+        #if os(tvOS)
+        button.onPrimaryActionTriggered.subscribe(with: self) { _ in
+            onPrimaryActionTriggeredCount += 1
+        }
+        #endif
+        
         let events: [UIControl.Event] = [.touchDown, .touchDownRepeat, .touchDragInside, .touchDragOutside,
                                          .touchDragEnter, .touchDragExit, .touchUpInside, .touchUpOutside,
                                          .touchCancel, .valueChanged, .editingDidBegin, .editingChanged,
@@ -80,6 +89,12 @@ class UIControl_SignalsTests: XCTestCase {
                 button.perform(Selector(action))
             }
         }
+        
+        #if os(tvOS)
+        for action in button.actions(forTarget: button, forControlEvent: .primaryActionTriggered)! {
+            button.perform(Selector(action))
+        }
+        #endif
 
         XCTAssertEqual(onTouchDownCount, 1, "Should have triggered once")
         XCTAssertEqual(onTouchDownRepeatCount, 1, "Should have triggered once")
@@ -95,6 +110,10 @@ class UIControl_SignalsTests: XCTestCase {
         XCTAssertEqual(onEditingChangedCount, 1, "Should have triggered once")
         XCTAssertEqual(onEditingDidEndCount, 1, "Should have triggered once")
         XCTAssertEqual(onEditingDidEndOnExitCount, 1, "Should have triggered once")
+        
+        #if os(tvOS)
+        XCTAssertEqual(onPrimaryActionTriggeredCount, 1, "Should have triggered once")
+        #endif
     }
 }
 


### PR DESCRIPTION
tvOS makes more extensive use of the .primaryActionTriggered UIControl.Event - this exposes a onPrimaryActionTriggered signal for UIControls - currently on tvOS only.

In theory this action can be used on iOS (I believe pressing the done button on the keyboard triggers this event in text fields for example) as well - but it is only available on iOS versions 9.0 and above and the library currently has a minimum iOS version of 8.0. This in theory could be cleaned up (removing the various #if os(tvOS) compiler conditional bits and returning the eventToKey to not use a closure to initialize) by bumping the min os version. Personally I doubt iOS 8 support has any value - but can't make that call for you.