### PR TITLE
Update Signals.podspec to iOS 9 base deployment

### DIFF
--- a/Signals.podspec
+++ b/Signals.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors = { 'Tuomas Artman' => 'tuomas@artman.fi' }
   s.source = { :git => 'https://github.com/artman/Signals.git', :tag => s.version }
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
   s.osx.deployment_target = '10.11'


### PR DESCRIPTION
<img width="463" alt="Screen Shot 2020-11-08 at 10 29 59 PM" src="https://user-images.githubusercontent.com/1163880/98497442-fe3b0000-2211-11eb-9c0f-b3c082efc278.png">

Update to iOS 9 minimum deployment target to silence warning.